### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Medable iOS SDK is targeted to be used in apps that have a base SDK of iOS 7
 Installation
 ======
 
-Using Cocoapods
+Using CocoaPods
 ------
 
 #### Step 1: Download CocoaPods

--- a/README.md
+++ b/README.md
@@ -1,163 +1,56 @@
-About the Medable SDK
-======
+### Usando o MoipSDK
 
-Welcome to the iOS Client SDK for [Medable](https://www.medable.com). This library provides a wrapper for the [Medable API](https://dev.medable.com/) as well as several helper tools to directly integrate those features to your iOS application.
+Veja abaixo como integrar o seu app com o Moip.
 
-The Medable iOS SDK is targeted to be used in apps that have a base SDK of iOS 7 and the following instructions are targeted for Xcode 6 users, consider updating if you have an older version.
 
-Installation
-======
+#### 1. Instalando
 
-Using CocoaPods
-------
+O SDK do Moip está no CocoaPods. Para instalar só adicionar ```pod 'MoipEncryptSDK', '~> 1.0'``` no seu ```Podfile```
 
-#### Step 1: Download CocoaPods
 
-[CocoaPods](http://cocoapods.org) is a dependency manager for Objective-C, which automates and simplifies the process of using 3rd-party libraries like Medable in your projects.
+#### 2. Criar o seu cartão de credito
 
-CocoaPods is distributed as a ruby gem, and is installed by running the following commands in your Terminal:
+```objective-c
+NSString *myPublicKey = @"";
+[MoipSDK importPublicKey:myPublicKey];
+```
 
-    $ sudo gem install cocoapods
-    $ pod setup
-
-> Depending on your Ruby installation, you may have to run as `sudo` to install the cocoapods gem.
-
-#### Step 2: Create a Podfile
-
-Project dependencies to be managed by CocoaPods are specified in a file called `Podfile`. Create this file in the same directory as your Xcode project (`.xcodeproj`) file.
-
-Copy and paste the following lines into the file:  
+#### 3. Criptografar os dados com base no seu MPKCreditCard
+```objective-c
+MPKCreditCard *creditCard = [MPKCreditCard new];
+creditCard.number = @"4111111111111111";
+creditCard.cvc = @"999";
+creditCard.expirationMonth = @"07";
+creditCard.expirationYear = @"15";
     
-    platform :ios, '7.0'
-    pod 'Medable'
+NSString * cryptData = [MoipSDK encryptCreditCard:creditCard];
+```
 
-#### Step 3: Install Dependencies
+### Validações
 
-Now you can install the dependencies in your project:
+Usando o MoipSDK, você pode realizar varias verificações para checar se os dados do cartão de credito.
 
-    $ pod install
-
-From now on, be sure to always open the generated Xcode workspace (`.xcworkspace`) instead of the project file when building your project:
-
-    $ open <YourProjectName>.xcworkspace
-
-That's it, you are now ready to use the Medable SDK. Head on over to the [Integration](#integration) guide to continue your setup.
-
-Manual Installation
-------
-
-Follow the [Manual Installation Guide](Documentation/manualInstall.md) for instructions on how to install the Medable iOS SDK manually.
-
-Swift
------
-
-The Medable SDK is written in Objective-C but using it from your Swift application is straightforward. Just add a bridging header to your app target:
-
-    //
-    //  MedableSwift-Bridging-Header.h
-    //  MedableSwift
-    //
-    //  Copyright (c) 2015 Medable Inc. All rights reserved.
-    //
-
-    #import <Medable/Medable.h>
-
-Make sure your Build Settings for the app target specify the bridging header (the entry is called `Objective-C Bridging Header`):
-
-    //:configuration = Debug
-    SWIFT_OBJC_BRIDGING_HEADER = MedableSwift/MedableSwift-Bridging-Header.h
+##### Número do cartão
+```objective-c
+MPKCreditCard *creditCard = [MPKCreditCard new];
+creditCard.number = @"4111111111111111";
     
-    //:configuration = Release
-    SWIFT_OBJC_BRIDGING_HEADER = MedableSwift/MedableSwift-Bridging-Header.h
-
-Finally, you can use Medable classes directly:
-
-    let client = Medable.client()
-
-Integration
-=====
-
-Configuring the Client
-------
-
-You need to provide a Medable Client Key and your Organization name to the SDK. The simplest way to do this is to add an entry to your app's ```plist``` file with this information.
-
-Here is a template of that format:
-
-```
-"Medable" : 
-{
-    "ClientKey": "SomeObscureString",
-    "Organization": "theclinic"
-}
+BOOL isValidCreditCard = creditCard.isNumberValid;
 ```
 
-The next figure shows how this would look when viewing the main ```.plist``` file:
-
-![Medable Entry](Documentation/png/dictionaryEntry.png)
-
-Other optional entries in the "Medable" dictionary include:
-
-- ```"url"```: Base URL of the medable backend, the default is ```"medable.com"```.
-- ```"Protocol"```: HTTP protocol used to communicate with the backend, the default is ```"https"```.
-- ```"APIPrefix"```: API Prefix of the backend, the default is ```"api"```.
-
-It's possible to also define different environments for different build configurations (Debug, Release, etc) and even define your custom configurations. For a walkthrough of those steps, follow the [Advanced Integration Steps Guide](Documentation/integrationSteps.md).
-
-
-Optional Integration Steps
-------
-
-### Start the Organization Content Download process along with your app
-
-It's not required, but is a good idea anyway, to initialize the Medable SDK in your app delegate, to do so just place this line in your app delegate:
-
+##### Código de segurança
 ```objective-c
-[Medable start];
+MPKCreditCard *creditCard = [MPKCreditCard new];
+creditCard.cvc = @"123";
+    
+BOOL isValid = creditCard.isSecurityCodeValid;
 ```
 
-You may also wish to register for notifications about that download process. To do so, check the [Advanced Integration Steps Guide](Documentation/integrationSteps.md) for further instructions.
-
-The reason this is a good idea is that Medable will be required to download your Organization's data before it can make other HTTP requests, if you don't initialize the SDK, this will happen when you make your first request, delaying it marginally.
-
-### Set log level
+##### Data de Expiração
 ```objective-c
-// Change log level
-[Medable client].loggerLevel = MDAPIClientNetworkLoggerLevelDebug;
-
-// If not set, the default loggerLevel is MDAPIClientNetworkLoggerLevelInfo.
+MPKCreditCard *creditCard = [MPKCreditCard new];
+creditCard.expirationMonth = @"06";
+creditCard.expirationYear = @"2018";
+    
+BOOL isValid = creditCard.isExpiryDateValid;
 ```
-
-### Handling particular events by listening to notifications.
-
-kMDNotificationAPIServerErrorDidOccur: This notification comes with the corresponding MDFault object, ready to be handled. Fault codes are listed in MDConstants.h.
-
-kMDNotificationUserDidLogout: This notification is used to forward the app to the login screen. This notification is thrown when the user logs out, or when API session is over because of an error or session timeout.
-
-Note: More notifications are defined in MDConstants.h.
-
-Getting Started
-======
-
-You can access the Medable iOS SDK API at [Cocoadocs](http://cocoadocs.org/docsets/Medable). The main API class is `MDAPIClient` which you can access by getting the shared client using this line:
-
-```objective-c
-MDAPIClient *medableAPI = [Medable client];
-```
-
-From there, check the SDK API, the examples or tutorials to accomplish specific things.
-
-Examples
-------
-
-Check out the [Code Samples](Documentation/examples.md) for a few examples on how to get some specific things done with the Medable SDK.
-
-Tutorials
-------
-
-Check out the [Tutorials](Documentation/tutorial.md)
-
-FAQ
-------
-
-Some common questions and answers can be found in the [FAQ](Documentation/faq.md).

--- a/README.md
+++ b/README.md
@@ -1,56 +1,65 @@
-### Usando o MoipSDK
+# Moltin iOS-SDK
 
-Veja abaixo como integrar o seu app com o Moip.
+The Moltin ios-sdk is a simple to use interface for the API to help you get off the ground quickly and efficiently within the iOS app.
 
+For full usage examples, check out the [Objective-C](https://github.com/moltin/ios-objc-example) example app, or the [Swift](https://github.com/moltin/ios-swift-example) example app.
 
-#### 1. Instalando
+## Installation
+There are two ways to install the Moltin SDK in your project:
 
-O SDK do Moip está no CocoaPods. Para instalar só adicionar ```pod 'MoipEncryptSDK', '~> 1.0'``` no seu ```Podfile```
+- Using CocoaPods (recommended)
+- Manual installation by copying all of the files in the Moltin directory into your project, and adding them to your target
 
+### Installation with CocoaPods
 
-#### 2. Criar o seu cartão de credito
+[CocoaPods](http://cocoapods.org/) is a dependency manager for Objective-C, which automates and simplifies the process of using 3rd-party libraries in your projects. See the [Get Started](http://cocoapods.org/#get_started) section for more details.
 
-```objective-c
-NSString *myPublicKey = @"";
-[MoipSDK importPublicKey:myPublicKey];
+#### Podfile
+```objc
+platform :ios, '7.0'
+
+pod 'Moltin', :git => 'https://github.com/moltin/ios-sdk.git', :branch => 'master'
 ```
 
-#### 3. Criptografar os dados com base no seu MPKCreditCard
-```objective-c
-MPKCreditCard *creditCard = [MPKCreditCard new];
-creditCard.number = @"4111111111111111";
-creditCard.cvc = @"999";
-creditCard.expirationMonth = @"07";
-creditCard.expirationYear = @"15";
-    
-NSString * cryptData = [MoipSDK encryptCreditCard:creditCard];
+
+#### Usage
+
+```objc
+#import <Moltin/Moltin.h>;
 ```
 
-### Validações
+### Authentication
 
-Usando o MoipSDK, você pode realizar varias verificações para checar se os dados do cartão de credito.
+Just set your store `public ID` from the API console on Moltin website and you are ready to go.
 
-##### Número do cartão
-```objective-c
-MPKCreditCard *creditCard = [MPKCreditCard new];
-creditCard.number = @"4111111111111111";
-    
-BOOL isValidCreditCard = creditCard.isNumberValid;
+```objc
+[[Moltin sharedInstance] setPublicId:@"XXXXXXXXXXXXX"];
 ```
 
-##### Código de segurança
-```objective-c
-MPKCreditCard *creditCard = [MPKCreditCard new];
-creditCard.cvc = @"123";
-    
-BOOL isValid = creditCard.isSecurityCodeValid;
+### Resources
+
+The majority of our API calls can be mapped to Model-esque instance and don't need any low-level API calls. A full example store app is included showing every part of the shopping process - from listing products, to adding them to a cart, and allowing the user to checkout (via credit card or Apple Pay).
+
+Get a single product by ID
+```objc
+[[Moltin sharedInstance].product getWithId:@"6"
+                                  callback:^(NSDictionary *response, NSError *error){
+                                            if(!error) {
+                                                NSLog(@"PRODUCT: %@", response);
+                                            } else {
+                                                NSLog(@"ERROR: %d", error.code);
+                                            }
+                                }];
 ```
 
-##### Data de Expiração
-```objective-c
-MPKCreditCard *creditCard = [MPKCreditCard new];
-creditCard.expirationMonth = @"06";
-creditCard.expirationYear = @"2018";
-    
-BOOL isValid = creditCard.isExpiryDateValid;
+Creating a user's address
+```objc
+[[Moltin sharedInstance].address createWithParameters:@{  @"first_name": @"Joe", @"last_name": @"Black" }
+                                			 callback:^(NSDictionary *response, NSError *error){
+						                                if(!error) {
+						                                    NSLog(@"Address created.");
+						                                } else {
+						                                    NSLog(@"ERROR: %d", error.code);
+						                                }
+                                }];
 ```


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
